### PR TITLE
Updating base class for the PSAT generators

### DIFF
--- a/iPSL/Electrical/Machines/PSAT/BaseClasses/baseMachine.mo
+++ b/iPSL/Electrical/Machines/PSAT/BaseClasses/baseMachine.mo
@@ -137,6 +137,8 @@ protected
   parameter Real w_b=2*pi*fn "Base frequency in rad/s";
 protected
   Real pe;
+initial equation
+  w = 1;
 equation
   v = sqrt(p.vr^2 + p.vi^2);
   anglev = atan2(p.vi, p.vr);


### PR DESCRIPTION
The issue #50 arose from the problem that was originally associated with the 6th order generator. However, the initial equation assigning 1 to the speed of the generator in the base class solved the problem. Close #50 
