### PR TITLE
Adding alternative way to display the copyright.

### DIFF
--- a/iPSL/Copyright.mo
+++ b/iPSL/Copyright.mo
@@ -1,5 +1,5 @@
 within iPSL;
-record Copyright "Disclaimer<html>
+class Copyright "Disclaimer<html>
 <p>Copyright &copy; 2015-2016 RTE (France), SmarTS Lab (Sweden), AIA (Spain) and DTU (Denmark)</p>
 <ul>
 <li>RTE: <a href=\"http://www.rte-france.com\">http://www.rte-france.com</a></li>

--- a/iPSL/Copyright.mo
+++ b/iPSL/Copyright.mo
@@ -1,15 +1,15 @@
-﻿within iPSL;
+within iPSL;
 record Copyright "Disclaimer<html>
 <p>Copyright &copy; 2015-2016 RTE (France), SmarTS Lab (Sweden), AIA (Spain) and DTU (Denmark)</p>
 <ul>
-<li>​RTE: <a href=\"http://www.rte-france.com\">http://www.rte-france.com</a></li>
+<li>RTE: <a href=\"http://www.rte-france.com\">http://www.rte-france.com</a></li>
 <li>SmarTS Lab, research group at KTH: <a href=\"https://www.kth.se/en\">https://www.kth.se/en</a></li>
-<li>​AIA: <a href=\"http://www.aia.es/en/energy\">http://www.aia.es/en/energy</a></li>
-<li>​DTU: <a href=\"http://www.dtu.dk/english\">http://www.dtu.dk/english</a></li>
+<li>AIA: <a href=\"http://www.aia.es/en/energy\">http://www.aia.es/en/energy</a></li>
+<li>DTU: <a href=\"http://www.dtu.dk/english\">http://www.dtu.dk/english</a></li>
 </ul>
 <p>The authors can be contacted by email: <a href=\"mailto:info@itesla-ipsl.org\">info@itesla-ipsl.org</a></p>
 <p>
-​​This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.<br>
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.<br>
 If a copy of the MPL was not distributed with this file, You can obtain one at
 <a href=\"http://mozilla.org/MPL/2.0/\">http://mozilla.org/MPL/2.0/</a>.
 </p>

--- a/iPSL/Copyright.mo
+++ b/iPSL/Copyright.mo
@@ -15,7 +15,8 @@ If a copy of the MPL was not distributed with this file, You can obtain one at
 </p>
 </html>"
 
-  annotation (Icon(graphics={Text(
+  annotation (preferredView="info", DocumentationClass=false,
+        Icon(graphics={Text(
           extent={{-100,140},{100,100}},
           lineColor={0,127,0},
           textString="%name%"),

--- a/iPSL/Copyright.mo
+++ b/iPSL/Copyright.mo
@@ -19,10 +19,22 @@ If a copy of the MPL was not distributed with this file, You can obtain one at
           extent={{-100,140},{100,100}},
           lineColor={0,127,0},
           textString="%name%"),
-        Text(
-          extent={{-100,90},{100,-80}},
-          lineColor={0,127,0},
-          textString="C",
-          textStyle={TextStyle.Bold}),
-        Ellipse(extent={{-100,100},{100,-100}}, lineColor={0,127,0})}));
+        Ellipse(extent={{-100,100},{100,-100}}, lineColor={0,127,0},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{-60,60},{60,-60}},
+          lineColor={0,127,72},
+          fillColor={0,127,0},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{-40,40},{40,-40}},
+          lineColor={255,255,255},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{28,22},{64,-20}},
+          lineColor={255,255,255},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid)}));
 end Copyright;

--- a/iPSL/Copyright.mo
+++ b/iPSL/Copyright.mo
@@ -20,7 +20,7 @@ If a copy of the MPL was not distributed with this file, You can obtain one at
           lineColor={0,127,0},
           textString="%name%"),
         Text(
-          extent={{-100,100},{100,-100}},
+          extent={{-100,90},{100,-80}},
           lineColor={0,127,0},
           textString="C",
           textStyle={TextStyle.Bold}),

--- a/iPSL/Copyright.mo
+++ b/iPSL/Copyright.mo
@@ -1,0 +1,28 @@
+﻿within iPSL;
+record Copyright "Disclaimer<html>
+<p>Copyright &copy; 2015-2016 RTE (France), SmarTS Lab (Sweden), AIA (Spain) and DTU (Denmark)</p>
+<ul>
+<li>​RTE: <a href=\"http://www.rte-france.com\">http://www.rte-france.com</a></li>
+<li>SmarTS Lab, research group at KTH: <a href=\"https://www.kth.se/en\">https://www.kth.se/en</a></li>
+<li>​AIA: <a href=\"http://www.aia.es/en/energy\">http://www.aia.es/en/energy</a></li>
+<li>​DTU: <a href=\"http://www.dtu.dk/english\">http://www.dtu.dk/english</a></li>
+</ul>
+<p>The authors can be contacted by email: <a href=\"mailto:info@itesla-ipsl.org\">info@itesla-ipsl.org</a></p>
+<p>
+​​This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.<br>
+If a copy of the MPL was not distributed with this file, You can obtain one at
+<a href=\"http://mozilla.org/MPL/2.0/\">http://mozilla.org/MPL/2.0/</a>.
+</p>
+</html>"
+
+  annotation (Icon(graphics={Text(
+          extent={{-100,140},{100,100}},
+          lineColor={0,127,0},
+          textString="%name%"),
+        Text(
+          extent={{-100,100},{100,-100}},
+          lineColor={0,127,0},
+          textString="C",
+          textStyle={TextStyle.Bold}),
+        Ellipse(extent={{-100,100},{100,-100}}, lineColor={0,127,0})}));
+end Copyright;

--- a/iPSL/Examples/DevelopmentExamples/Electrical/Machines/PSSE/GENROU.mo
+++ b/iPSL/Examples/DevelopmentExamples/Electrical/Machines/PSSE/GENROU.mo
@@ -112,16 +112,9 @@ equation
   connect(GEN.p, pwLine.p) annotation (Line(points={{-34,10},{-23,10}}, color={0,0,255}));
   annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,100}})), Documentation(revisions="<html>
 <!--DISCLAIMER-->
-<p>Copyright 2015-2016 RTE (France), SmarTS Lab (Sweden), AIA (Spain) and DTU (Denmark)</p>
-<ul>
-<li>RTE: <a href=\"http://www.rte-france.com\">http://www.rte-france.com</a></li>
-<li>SmarTS Lab, research group at KTH: <a href=\"https://www.kth.se/en\">https://www.kth.se/en</a></li>
-<li>AIA: <a href=\"http://www.aia.es/en/energy\"> http://www.aia.es/en/energy</a></li>
-<li>DTU: <a href=\"http://www.dtu.dk/english\"> http://www.dtu.dk/english</a></li>
-</ul>
-<p>The authors can be contacted by email: <a href=\"mailto:info@itesla-ipsl.org\">info@itesla-ipsl.org</a></p>
-
-<p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. </p>
-<p>If a copy of the MPL was not distributed with this file, You can obtain one at <a href=\"http://mozilla.org/MPL/2.0/\"> http://mozilla.org/MPL/2.0</a>.</p>
+<h5>DISCLAIMER</h5>
+<p>This file is subject to the terms and conditions defined in
+<a href=\"modelica://iPSL.Copyright\">iPSL.Copyright</a>,
+which is part of this source code package.</p>
 </html>"));
 end GENROU;

--- a/iPSL/Examples/DevelopmentExamples/Electrical/Machines/PSSE/GENROU.mo
+++ b/iPSL/Examples/DevelopmentExamples/Electrical/Machines/PSSE/GENROU.mo
@@ -1,7 +1,6 @@
 within iPSL.Examples.DevelopmentExamples.Electrical.Machines.PSSE;
 model GENROU "SMIB system with one load and GENROE model"
   import iPSL;
-
   iPSL.Electrical.Branches.PwLine pwLine(
     R=0.001,
     X=0.2,
@@ -77,6 +76,7 @@ model GENROU "SMIB system with one load and GENROE model"
     Xpp=0.2,
     H=4.28) annotation (Placement(transformation(extent={{-82,-10},{-42,30}})));
   iPSL.Electrical.Buses.Bus GEN annotation (Placement(transformation(extent={{-44,0},{-24,20}})));
+  iPSL.Copyright copyright annotation (Placement(transformation(extent={{-100,-100},{-80,-80}})));
 equation
   connect(pwLine.n, pwLine1.p) annotation (Line(
       points={{-9,10},{3.5,10},{3.5,24},{29,24}},

--- a/iPSL/package.order
+++ b/iPSL/package.order
@@ -1,3 +1,4 @@
+Copyright
 Examples
 Electrical
 NonElectrical


### PR DESCRIPTION
The copyright information needs only be provided in
`Copyright` and then an instance of this class should be
placed in all models. Any "local" copyright notice can
be removed.

Updates need only be done in `Copyright`.

Two nice features:
1. By using the HTML capabilities of the description one gets a nice mouse over display:
   ![screenshot from 2016-02-04 09-22-15](https://cloud.githubusercontent.com/assets/9332/12809662/22a5b522-cb21-11e5-99e1-ab522f52d50f.png) (works in Dymola and OM)
2. After the copyright record (I've chosen that type since it is not supposed to have any equation and MA tries to get away from the usage of `class` as general well class) is dragged into the diagram of the models you can simply double click on the `copyright` component in the diagram layer and get the copyright displayed. I've created one example in `iPSL.Examples.DevelopmentExamples.Electrical.Machines.PSSE.GENROU`
   ![screenshot from 2016-02-04 09-32-57](https://cloud.githubusercontent.com/assets/9332/12809810/4de75014-cb22-11e5-93b3-4c0d93564de0.png) (works in Dymola and ~~most likely soon~~ also in OM(see [OM ticket 3665](https://trac.openmodelica.org/OpenModelica/ticket/3665)))

Drawbacks I can think of is that when looking at the modelica source code the disclaimer is not presented directly but you would only see something like
`iPSL.Copyright copyright annotation (Placement(transformation(extent={{-100,-100},{-80,-80}})));`
Still this at least points to the Copyright and if you are worried about this you could also add a description to the instance making it explicit. E.g., 
`iPSL.Copyright copyright "See iPSL.Copyright for conditions of use" annotation(...);`. I think this would be an overkill to be honest.
