### PR TITLE
Fix to correct error in baseLoad

### DIFF
--- a/iPSL/Electrical/Loads/PSSE/BaseClasses/baseLoad.mo
+++ b/iPSL/Electrical/Loads/PSSE/BaseClasses/baseLoad.mo
@@ -33,9 +33,9 @@ protected
   parameter Real vi0=V_0*sin(anglev_rad) "Initialitation";
   parameter Real ir0=(p0*vr0 + q0*vi0)/(vr0^2 + vi0^2) "Initialitation";
   parameter Real ii0=(p0*vi0 - q0*vr0)/(vr0^2 + vi0^2) "Initialitation";
-  parameter Complex S_P=(Complex((1 - a.re - b.re)*S_p.re, (1 - a.im - b.im)*S_p.im))/S_b;
-  parameter Complex S_I=(S_i + Complex(a.re*S_p.re/V_0, a.im*S_p.im/V_0))/S_b;
-  parameter Complex S_Y=(S_y + Complex(b.re*S_p.re/V_0^2, b.im*S_p.im/V_0^2))/S_b;
+  parameter Complex S_P=(Complex((1 - a.re - b.re)*S_p.re, (1 - a.im - b.im)*S_p.im))/S_b "pu";
+  parameter Complex S_I=(S_i + Complex(a.re*S_p.re/V_0, a.im*S_p.im/V_0))/S_b "pu";
+  parameter Complex S_Y=(S_y + Complex(b.re*S_p.re/V_0^2, b.im*S_p.im/V_0^2))/S_b "pu";
   //Constant current load vary function when voltage is below 0.5
   parameter Real a2=1.502;
   parameter Real b2=1.769;

--- a/iPSL/Electrical/Loads/PSSE/BaseClasses/baseLoad.mo
+++ b/iPSL/Electrical/Loads/PSSE/BaseClasses/baseLoad.mo
@@ -4,11 +4,16 @@ partial model baseLoad
   import Modelica.ComplexMath.j;
   extends iPSL.Electrical.Essentials.pfComponent;
 
-  parameter Complex S_p=P_0 + j*Q_0 "Consumption of original constant power load (MVA)";
-  parameter Complex S_i=0 + j*0 "Consumption of original constant current load (MVA)";
-  parameter Complex S_y=0 + j*0 "Consumption of original constant shunt admittance load (MVA)";
-  parameter Complex a=1 + j*0 "Load transfer fraction for constant current load";
-  parameter Complex b=0 + j*1 "Load transfer fraction for constant shunt admittance load";
+  parameter Complex S_p=P_0 + j*Q_0
+    "Consumption of original constant power load (MVA)";
+  parameter Complex S_i=0 + j*0
+    "Consumption of original constant current load (MVA)";
+  parameter Complex S_y=0 + j*0
+    "Consumption of original constant shunt admittance load (MVA)";
+  parameter Complex a=1 + j*0
+    "Load transfer fraction for constant current load";
+  parameter Complex b=0 + j*1
+    "Load transfer fraction for constant shunt admittance load";
   parameter Real PQBRAK=0.7 "Constant power characteristic threshold";
   parameter Integer characteristic=1 annotation (choices(choice=1, choice=2));
   iPSL.Connectors.PwPin p(
@@ -22,15 +27,15 @@ partial model baseLoad
   Real Q "Reactive power consumption (pu)";
 protected
   parameter Real anglev_rad=angle_0*pi/180;
-  parameter Real p0=S_i.re*V_0 + S_y.re*V_0^2 + S_p.re;
-  parameter Real q0=S_i.im*V_0 + S_y.im*V_0^2 + S_p.im;
+  parameter Real p0=(S_i.re*V_0 + S_y.re*V_0^2 + S_p.re)/S_b "pu";
+  parameter Real q0=(S_i.im*V_0 + S_y.im*V_0^2 + S_p.im)/S_b "pu";
   parameter Real vr0=V_0*cos(anglev_rad) "Initialitation";
   parameter Real vi0=V_0*sin(anglev_rad) "Initialitation";
   parameter Real ir0=(p0*vr0 + q0*vi0)/(vr0^2 + vi0^2) "Initialitation";
   parameter Real ii0=(p0*vi0 - q0*vr0)/(vr0^2 + vi0^2) "Initialitation";
-  parameter Complex S_P=Complex((1 - a.re - b.re)*S_p.re, (1 - a.im - b.im)*S_p.im);
-  parameter Complex S_I=S_i + Complex(a.re*S_p.re/V_0, a.im*S_p.im/V_0);
-  parameter Complex S_Y=S_y + Complex(b.re*S_p.re/V_0^2, b.im*S_p.im/V_0^2);
+  parameter Complex S_P=(Complex((1 - a.re - b.re)*S_p.re, (1 - a.im - b.im)*S_p.im))/S_b;
+  parameter Complex S_I=(S_i + Complex(a.re*S_p.re/V_0, a.im*S_p.im/V_0))/S_b;
+  parameter Complex S_Y=(S_y + Complex(b.re*S_p.re/V_0^2, b.im*S_p.im/V_0^2))/S_b;
   //Constant current load vary function when voltage is below 0.5
   parameter Real a2=1.502;
   parameter Real b2=1.769;

--- a/iPSL/Examples/Machines/PSSE/GENROU.mo
+++ b/iPSL/Examples/Machines/PSSE/GENROU.mo
@@ -36,18 +36,15 @@ model GENROU "SMIB system with one load and GENROE model"
     Q_0=8.006544,
     H=0) annotation (Placement(transformation(extent={{108,0},{86,22}})));
   iPSL.Electrical.Loads.PSSE.Load_variation constantLoad(
-    S_p(re=0.5, im=0.1),
-    S_i(im=0, re=0),
-    S_y(re=0, im=0),
-    a(re=1, im=0),
-    b(re=0, im=1),
     PQBRAK=0.7,
     d_t=0,
     d_P=0,
     V_0=0.9919935,
     angle_0=-0.5762684,
     t1=0,
-    characteristic=2) annotation (Placement(transformation(extent={{8,-52},{30,-28}})));
+    characteristic=2,
+    P_0=50,
+    Q_0=10)           annotation (Placement(transformation(extent={{8,-52},{30,-28}})));
   iPSL.Electrical.Events.PwFault pwFault(
     t1=2,
     t2=2.15,
@@ -77,6 +74,8 @@ model GENROU "SMIB system with one load and GENROE model"
     Xpp=0.2,
     H=4.28) annotation (Placement(transformation(extent={{-82,-10},{-42,30}})));
   iPSL.Electrical.Buses.Bus GEN annotation (Placement(transformation(extent={{-44,0},{-24,20}})));
+  inner iPSL.Electrical.SystemBase SysData
+    annotation (Placement(transformation(extent={{-98,78},{-46,98}})));
 equation
   connect(pwLine.n, pwLine1.p) annotation (Line(
       points={{-9,10},{3.5,10},{3.5,24},{29,24}},


### PR DESCRIPTION
- Fixed baseLoad so that the different internal powers of the ZIP are expressed in pu. The external powers are still given in MVA.
- Update in GENROU test-model to show that the fix is working as intended. More examples using PSS/E loads will need to be updated.
