### PR TITLE
Add P_0 and Q_0 to Eurostag machine models

### DIFF
--- a/iPSL/Electrical/Machines/Eurostag/PwGeneratorM1S.mo
+++ b/iPSL/Electrical/Machines/Eurostag/PwGeneratorM1S.mo
@@ -59,8 +59,8 @@ model PwGeneratorM1S "Synchronous machine model according to Park's classical th
   "Initial imaginary voltage component p.u. in the SNREF base";
   //parameter Real ir0 = 1;
   //parameter Real ii0 = 0;
-  //parameter Real p0_0 = 0 "Initial active power";
-  //parameter Real q0_0 = 0 "Initial active power";
+  parameter Real P_0 = 0 "Initial active power (MW)";
+  parameter Real Q_0 = 0 "Initial active power (MVA)";
   //General parameters.
   parameter Real omega0 = 2 * 3.14159265 * 50
     "Nominal network angular frequency";

--- a/iPSL/Electrical/Machines/Eurostag/PwGeneratorM2S.mo
+++ b/iPSL/Electrical/Machines/Eurostag/PwGeneratorM2S.mo
@@ -85,8 +85,8 @@ model PwGeneratorM2S "Synchronous machine model according to Park's classical th
   "Initial imaginary voltage component p.u. in the SNREF base";
     //   parameter Real ir0 = 1;
     //   parameter Real ii0 = 0;
- // parameter Real p0_0=0 "Initial active power";
- // parameter Real q0_0=0 "Initial active power";
+  parameter Real P_0=0 "Initial active power (MW)";
+  parameter Real Q_0=0 "Initial active power (MVA)";
   // EXTERNAL PARAMETERS (GIVEN) per-unit in the machine SN base.
   parameter Real rStatIn=0 "Stator resistance p.u. in the machine SN base";
   parameter Real lStatIn=0 "Stator leakage p.u. in the machine SN base";


### PR DESCRIPTION
These initial active and reactive power are used at initialization machine model but not in the Eurostag machine model. In this cases P_0 and Q_O are just informative 